### PR TITLE
Replace `nickname` with `username` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project is about creating image search engine for the discipline "Artificia
 ## Team and roles
 
 Here is our squad and roles:
-| № | Surname and name | Academic group | GitHub nickname | Role |
+| № | Surname and name | Academic group | GitHub username | Role |
 | --- | --- | --- | --- | --- | 
 | 1 | Кравчук Аркадій | КП-11мн | [@akrava](https://github.com/akrava) | team lead |
 | 2 | Песчанський Даниїл | КП-11мн | [@danya-psch](https://github.com/danya-psch) | developer |


### PR DESCRIPTION
Changed to `username` in heading of team's info table
Fixes issue #1